### PR TITLE
[Fixes #37] Adds automatic (js) redirects for admin only pages

### DIFF
--- a/client/hbs/admin.hbs
+++ b/client/hbs/admin.hbs
@@ -25,6 +25,6 @@
 		{{/each}}
 	</main>
 	{{else}}
-	Please <a href="/google/login">log in</a> first.
+		{{> no-admin.hbs}}
 	{{/if}}
 </html>

--- a/client/hbs/editor.hbs
+++ b/client/hbs/editor.hbs
@@ -34,6 +34,6 @@
 	</body>
 
 	{{else}}
-	You must be <a href="/google/login">logged in</a> to use this page
+		{{> no-admin.hbs}}
 	{{/if}}
 </html>

--- a/client/hbs/no-admin.hbs
+++ b/client/hbs/no-admin.hbs
@@ -1,0 +1,11 @@
+{{> head.hbs}}
+<body>
+	<h1>Please <a href="/google/login">log in</a> to access this page.</h1>
+	<h3>If you encountered this page by accident, you may hit the back arrow. Otherwise, you will be automatically redirected in a few seconds</h3>
+	<script>
+		setTimeout(function() {
+			window.location.href="/google/login"
+		}, 4000)
+	</script>
+</body>
+

--- a/client/hbs/page.hbs
+++ b/client/hbs/page.hbs
@@ -1,4 +1,7 @@
 <html>
+	{{#if restricted}}
+		{{> no-admin.hbs}}
+	{{else}}
 	{{> head.hbs}}
 	<body>
 		{{> header.hbs}}
@@ -47,4 +50,5 @@
 			</aside>
 		</content-row>
 	</body>
+	{{/if}}
 </html>


### PR DESCRIPTION
I opted for JS instead of HTTP for both stylistic reasons (it would require a change in the way renderer is designed) and for functional reasons (this way we can show a message for a few seconds before redirecting)
