### PR TITLE
Change highlight.js dependency for TS patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gulp-sass": "^2.1.0",
     "gulp-uglify": "^1.5.1",
     "handlebars": "^4.0.5",
-    "highlight.js": "^9.3.0",
+    "highlight.js": "github:bluepichu/highlight.js#build",
     "marked": "^0.3.5",
     "mkdirp": "^0.5.1",
     "moment": "^2.10.6",


### PR DESCRIPTION
Since HLJS is probably not going to have its next release (including [my patch](https://github.com/isagalaev/highlight.js/pull/1221)) for a while, set up a temporary dependency on my fork.

Based on HLJS's update cycle, we should expect 9.5.0 at the beginning of July.
