### PR TITLE
[Fixes #102] Move highlight.js dependency back to release

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "gulp-sass": "^2.1.0",
     "gulp-uglify": "^1.5.1",
     "handlebars": "^4.0.5",
-    "highlight.js": "github:bluepichu/highlight.js#build",
+    "highlight.js": "^9.5.0",
     "markdown-it": "^6.1.0",
     "markdown-it-anchor": "^2.5.0",
     "markdown-it-attrs": "^0.6.0",


### PR DESCRIPTION
Title.
